### PR TITLE
Fix GCC and Clang warnings that cause the build to fail

### DIFF
--- a/vpk_fuse.c
+++ b/vpk_fuse.c
@@ -265,7 +265,8 @@ char* ReadString(int fd) {
 	static char buf[512];
 	char c = 0; int count = 0;
 	while (true) {
-		read(fd, &c, 1);
+		if (read(fd, &c, 1) <= 0)
+			break;
 		if (c == 0)
 			break;
 		if (count < 512) // Discard the rest TODO: do better
@@ -278,15 +279,21 @@ char* ReadString(int fd) {
 }
 
 int ReadInt(int fd) {
-	int i; read(fd, &i, sizeof(int));
+	int i;
+	if (read(fd, &i, sizeof(int)) <= 0)
+		i = 0;
 	return i;
 }
 unsigned int ReadUInt(int fd) {
-	unsigned int i; read(fd, &i, sizeof(unsigned int));
+	unsigned int i;
+	if (read(fd, &i, sizeof(unsigned int)) <= 0)
+		i = 0;
 	return i;
 }
 unsigned short ReadUShort(int fd) {
-	unsigned short i; read(fd, &i, sizeof(unsigned short));
+	unsigned short i;
+	if (read(fd, &i, sizeof(unsigned short)) <= 0)
+		i = 0;
 	return i;
 }
 

--- a/vpk_fuse.c
+++ b/vpk_fuse.c
@@ -325,33 +325,22 @@ int OpenVPKArchive(VPK *const vpk, int id) {
 		size_t prefLen = strlen(prefix), suffLen = strlen(suffix);
 		size_t fnameLen = vpk->PathLen + prefLen + 3 + suffLen + 1;
 		char *fname = malloc(fnameLen);
-
-		// Suppress weird GCC warning that is treated as an error
-		#ifdef __GNUC__
-		#ifndef __clang__
-		#pragma GCC diagnostic push
-		#pragma GCC diagnostic ignored "-Wformat-truncation"
-		#endif
-		#endif
 		
 		// 3-len id
-		snprintf(fname, fnameLen, "%s%s%03d%s", vpk->Path, prefix, id % 1000u, suffix);
+		int written = snprintf(fname, fnameLen, "%s%s%03d%s", vpk->Path, prefix, id % 1000u, suffix);
 		if ((fd = open(fname, O_RDONLY)) != -1) goto OpenVPKArchiveEndTry;
 		
 		// 2-len id
-		snprintf(fname, fnameLen, "%s%s%02d%s", vpk->Path, prefix, id % 100u, suffix);
+		written = snprintf(fname, fnameLen, "%s%s%02d%s", vpk->Path, prefix, id % 100u, suffix);
 		if ((fd = open(fname, O_RDONLY)) != -1) goto OpenVPKArchiveEndTry;
-
-		#ifdef __GNUC__
-		#ifndef __clang__
-		#pragma GCC diagnostic pop
-		#endif
-		#endif
 		
 		// any-required-len id
-		snprintf(fname, fnameLen, "%s%s%d%s", vpk->Path, prefix, id, suffix);
+		written = snprintf(fname, fnameLen, "%s%s%d%s", vpk->Path, prefix, id, suffix);
 		if ((fd = open(fname, O_RDONLY)) != -1) goto OpenVPKArchiveEndTry;
 		
+		if ((size_t) written >= fnameLen) {
+			LogE("Filename too long for archive #%d", id);
+		}
 		LogE("Could not find a suitable file for archive #%d", id);
 		return -1;
 		

--- a/vpk_fuse.c
+++ b/vpk_fuse.c
@@ -222,7 +222,7 @@ DirectoryEntry* AddDirectory(const char *const path, const char *const name) {
 	return AddEntry(path, &ent);
 }
 
-void InitFileSystem() {
+void InitFileSystem(void) {
 	rootEntry.IsDirectory = true;
 	rootEntry.Name = strdup("/");
 	rootEntry.Data = &root;
@@ -257,7 +257,7 @@ void DestructDirectoryEntry(const DirectoryEntry *const ent, bool notroot) {
 		free(dir);
 }
 
-void DestructFileSystem() {
+void DestructFileSystem(void) {
 	DestructDirectoryEntry(&rootEntry, false);
 }
 

--- a/vpk_fuse.c
+++ b/vpk_fuse.c
@@ -322,19 +322,34 @@ int OpenVPKArchive(VPK *const vpk, int id) {
 		char *prefix = malloc(diroff+1);
 		const char *suffix = vpk->FileName+diroff+3;
 		memcpy(prefix, vpk->FileName, diroff); prefix[diroff] = 0;
-		int prefLen = strlen(prefix), suffLen = strlen(suffix);
-		char *fname = malloc(vpk->PathLen + prefLen + 3 + suffLen + 1);
+		size_t prefLen = strlen(prefix), suffLen = strlen(suffix);
+		size_t fnameLen = vpk->PathLen + prefLen + 3 + suffLen + 1;
+		char *fname = malloc(fnameLen);
+
+		// Suppress weird GCC warning that is treated as an error
+		#ifdef __GNUC__
+		#ifndef __clang__
+		#pragma GCC diagnostic push
+		#pragma GCC diagnostic ignored "-Wformat-truncation"
+		#endif
+		#endif
 		
 		// 3-len id
-		sprintf(fname, "%s%s%03d%s", vpk->Path, prefix, id, suffix);
+		snprintf(fname, fnameLen, "%s%s%03d%s", vpk->Path, prefix, id % 1000u, suffix);
 		if ((fd = open(fname, O_RDONLY)) != -1) goto OpenVPKArchiveEndTry;
 		
 		// 2-len id
-		sprintf(fname, "%s%s%02d%s", vpk->Path, prefix, id, suffix);
+		snprintf(fname, fnameLen, "%s%s%02d%s", vpk->Path, prefix, id % 100u, suffix);
 		if ((fd = open(fname, O_RDONLY)) != -1) goto OpenVPKArchiveEndTry;
+
+		#ifdef __GNUC__
+		#ifndef __clang__
+		#pragma GCC diagnostic pop
+		#endif
+		#endif
 		
 		// any-required-len id
-		sprintf(fname, "%s%s%d%s", vpk->Path, prefix, id, suffix);
+		snprintf(fname, fnameLen, "%s%s%d%s", vpk->Path, prefix, id, suffix);
 		if ((fd = open(fname, O_RDONLY)) != -1) goto OpenVPKArchiveEndTry;
 		
 		LogE("Could not find a suitable file for archive #%d", id);


### PR DESCRIPTION
I ended up just ignoring the GCC warning because it seems to be redundant in this case.
Edit: Removed ignoring the warning by checking the return values